### PR TITLE
Feature/rename niftycloud to nifcloud

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}"}
 
-# Specify your gem's dependencies in niftycloud.gemspec
+# Specify your gem's dependencies in nifcloud.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# Unofficial NIFTY Cloud SDK for Ruby
+# Unofficial NIF Cloud SDK for Ruby
 
 ## 概要
-ニフティクラウド(IaaS)から提供されているAPIを利用し、サーバー作成等の操作を可能にするSDKです。
+ニフクラ(IaaS)から提供されているAPIを利用し、サーバー作成等の操作を可能にするSDKです。
 
 ## インストール
 ```
-gem install niftycloud
+gem install nifcloud
 ```
 
 ## 使い方
 ```
-$ export NIFTYCLOUD_ACCESS_KEY_ID=XXXXXXXXXXXXXXXXXX
-$ export NIFTYCLOUD_SECRET_ACCESS_KEY=YYYYYYYYYYYYYYYYYYY
+$ export NIFCLOUD_ACCESS_KEY_ID=XXXXXXXXXXXXXXXXXX
+$ export NIFCLOUD_SECRET_ACCESS_KEY=YYYYYYYYYYYYYYYYYYY
 ```

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "niftycloud"
+require "nifcloud"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/nifcloud.rb
+++ b/lib/nifcloud.rb
@@ -1,17 +1,17 @@
-require 'niftycloud/version'
-require 'niftycloud/objectified_hash'
-require 'niftycloud/error'
-require 'niftycloud/signature'
-require 'niftycloud/configuration'
-require 'niftycloud/request'
-require 'niftycloud/api'
-require 'niftycloud/client'
+require 'nifcloud/version'
+require 'nifcloud/objectified_hash'
+require 'nifcloud/error'
+require 'nifcloud/signature'
+require 'nifcloud/configuration'
+require 'nifcloud/request'
+require 'nifcloud/api'
+require 'nifcloud/client'
 
-module Niftycloud
+module Nifcloud
   extend Configuration
 
   def self.client(options={})
-    Niftycloud::Client.new(options)
+    Nifcloud::Client.new(options)
   end
 
   def self.method_missing(method, *args, &block)
@@ -24,6 +24,6 @@ module Niftycloud
   end
 
   def self.http_proxy(address=nil, port=nil, username=nil, password=nil)
-    Niftycloud::Request.set_proxy_config(address, port, username, password)
+    Nifcloud::Request.set_proxy_config(address, port, username, password)
   end
 end

--- a/lib/nifcloud/api.rb
+++ b/lib/nifcloud/api.rb
@@ -1,9 +1,9 @@
-module Niftycloud
+module Nifcloud
   class API < Request
     attr_accessor(*Configuration::VALID_OPTIONS_KEYS)
 
     def initialize(options={})
-      options = Niftycloud.options.merge(options)
+      options = Nifcloud.options.merge(options)
       (Configuration::VALID_OPTIONS_KEYS + [:secret_key]).each do |key|
         send("#{key}=", options[key]) if options[key]
       end

--- a/lib/nifcloud/client.rb
+++ b/lib/nifcloud/client.rb
@@ -1,4 +1,4 @@
-module Niftycloud
+module Nifcloud
   class Client < API
     Dir[File.expand_path('../client/*.rb', __FILE__)].each {|f| require f}
 

--- a/lib/nifcloud/client/Instances.rb
+++ b/lib/nifcloud/client/Instances.rb
@@ -1,4 +1,4 @@
-class Niftycloud::Client
+class Nifcloud::Client
   module Instances
     def DescribeInstances(options={})
       options[:Action] = 'DescribeInstances'

--- a/lib/nifcloud/client/issues.rb
+++ b/lib/nifcloud/client/issues.rb
@@ -1,4 +1,4 @@
-class Niftycloud::Client
+class Nifcloud::Client
   module Issues
 
     def issues(project=nil, options={})

--- a/lib/nifcloud/configuration.rb
+++ b/lib/nifcloud/configuration.rb
@@ -1,7 +1,7 @@
-module Niftycloud
+module Nifcloud
   module Configuration
     VALID_OPTIONS_KEYS = [:endpoint, :secret_key, :access_key, :user_agent, :debug].freeze
-    DEFAULT_USER_AGENT = "Niftycloud Ruby Gem #{Niftycloud::VERSION}".freeze
+    DEFAULT_USER_AGENT = "Nifcloud Ruby Gem #{Nifcloud::VERSION}".freeze
 
     attr_accessor(*VALID_OPTIONS_KEYS)
 
@@ -20,9 +20,9 @@ module Niftycloud
     end
 
     def reset
-      self.endpoint = ENV['NIFTYCLOUD_API_ENDPOINT']
-      self.secret_key = ENV['NIFTYCLOUD_API_SECRET_KEY']
-      self.access_key = ENV['NIFTYCLOUD_API_ACCESS_KEY']
+      self.endpoint = ENV['NIFCLOUD_API_ENDPOINT']
+      self.secret_key = ENV['NIFCLOUD_API_SECRET_KEY']
+      self.access_key = ENV['NIFCLOUD_API_ACCESS_KEY']
       self.debug = nil
       self.user_agent = DEFAULT_USER_AGENT
     end

--- a/lib/nifcloud/error.rb
+++ b/lib/nifcloud/error.rb
@@ -1,4 +1,4 @@
-module Niftycloud
+module Nifcloud
   module Error
     # Custom error class for rescuing from all errors.
     class Error < StandardError;
@@ -41,7 +41,7 @@ module Niftycloud
       # Handle error response message in case of nested hashes
       def handle_message(message)
         case message
-          #when Niftycloud::ObjectifiedHash
+          #when Nifcloud::ObjectifiedHash
           #  message.to_h.sort.map do |key, val|
           #    "'#{key}' #{(val.is_a?(Hash) ? val.sort.map { |k, v| "(#{k}: #{v.join(' ')})" } : val).join(' ')}"
           #  end.join(', ')

--- a/lib/nifcloud/objectified_hash.rb
+++ b/lib/nifcloud/objectified_hash.rb
@@ -1,4 +1,4 @@
-module Niftycloud
+module Nifcloud
   module ObjectifiedHash
     def method_missing(meth, *args, &block)
       if args.size == 0

--- a/lib/nifcloud/request.rb
+++ b/lib/nifcloud/request.rb
@@ -1,7 +1,7 @@
 require 'httpclient'
 require 'xmlsimple'
 
-module Niftycloud
+module Nifcloud
   class Request
     attr_accessor :secret_key, :access_key, :endpoint
 

--- a/lib/nifcloud/signature.rb
+++ b/lib/nifcloud/signature.rb
@@ -2,7 +2,7 @@ require 'openssl'
 require 'base64'
 require 'cgi/util'
 
-module Niftycloud
+module Nifcloud
   class Signature
     def self.v0(key, data)
       Base64.encode64(OpenSSL::HMAC.digest("sha1", key.encode("utf-8"), data.encode("utf-8"))).chomp

--- a/lib/nifcloud/version.rb
+++ b/lib/nifcloud/version.rb
@@ -1,3 +1,3 @@
-module Niftycloud
+module Nifcloud
   VERSION = "0.0.1"
 end

--- a/nifcloud.gemspec
+++ b/nifcloud.gemspec
@@ -1,17 +1,17 @@
 # coding: utf-8
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "niftycloud/version"
+require "nifcloud/version"
 
 Gem::Specification.new do |spec|
-  spec.name = "niftycloud"
-  spec.version = Niftycloud::VERSION
+  spec.name = "nifcloud"
+  spec.version = Nifcloud::VERSION
   spec.authors = ["Kazuki Iwata"]
   spec.email = ["kazu.0516.k0n0f@gmail.com"]
 
-  spec.summary = %q{Unofficial NIFTY Cloud SDK for Ruby}
-  spec.description = %q{The Unofficial NIFTY Cloud SDK for Ruby}
-  spec.homepage = "https://github.com/kzmake/niftycloud"
+  spec.summary = %q{Unofficial NIFCLOUD SDK for Ruby}
+  spec.description = %q{The Unofficial NIFCLOUD SDK for Ruby}
+  spec.homepage = "https://github.com/kzmake/nifcloud"
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})

--- a/spec/niftycloud/client/instances_spec.rb
+++ b/spec/niftycloud/client/instances_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe Niftycloud::Client do
+describe Nifcloud::Client do
   describe ".instances" do
     context "Action: DescribeInstances" do
       before do
         stub_get("/", "DescribeInstances", "instances")
-        @instances = Niftycloud.DescribeInstances
+        @instances = Nifcloud.DescribeInstances
       end
 
       it "should get the correct resource" do
@@ -13,7 +13,7 @@ describe Niftycloud::Client do
       end
 
       it "should return a response of instances" do
-        expect(@instances).to be_a Niftycloud::ObjectifiedHash
+        expect(@instances).to be_a Nifcloud::ObjectifiedHash
         expect(@instances.reservationSet[0].instancesSet[0].instanceId).to eq("test")
       end
     end

--- a/spec/niftycloud/request_spec.rb
+++ b/spec/niftycloud/request_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-RSpec.describe Niftycloud::Request do
+RSpec.describe Nifcloud::Request do
   it {should respond_to :get}
   it {should respond_to :post}
   it {should respond_to :put}
   it {should respond_to :delete}
   before do
-    @request = Niftycloud::Request.new
+    @request = Nifcloud::Request.new
   end
 end

--- a/spec/niftycloud_spec.rb
+++ b/spec/niftycloud_spec.rb
@@ -1,16 +1,16 @@
 require 'spec_helper'
 
-describe Niftycloud do
-  after {Niftycloud.reset}
+describe Nifcloud do
+  after {Nifcloud.reset}
 
   describe ".client" do
-    it "should be a Niftycloud::Client" do
-      expect(Niftycloud.client).to be_a Niftycloud::Client
+    it "should be a Nifcloud::Client" do
+      expect(Nifcloud.client).to be_a Nifcloud::Client
     end
 
     it "should not override each other" do
-      client1 = Niftycloud.client(endpoint: 'https://api1.example.com', secret_key: '001')
-      client2 = Niftycloud.client(endpoint: 'https://api2.example.com', secret_key: '002')
+      client1 = Nifcloud.client(endpoint: 'https://api1.example.com', secret_key: '001')
+      client2 = Nifcloud.client(endpoint: 'https://api2.example.com', secret_key: '002')
       expect(client1.endpoint).to eq('https://api1.example.com')
       expect(client2.endpoint).to eq('https://api2.example.com')
       expect(client1.secret_key).to eq('001')
@@ -20,56 +20,56 @@ describe Niftycloud do
 
   describe ".endpoint =" do
     it "should set endpoint" do
-      Niftycloud.endpoint = 'https://api.example.com'
-      expect(Niftycloud.endpoint).to eq('https://api.example.com')
+      Nifcloud.endpoint = 'https://api.example.com'
+      expect(Nifcloud.endpoint).to eq('https://api.example.com')
     end
   end
 
   describe ".secret_key =" do
     it "should set secret_key" do
-      Niftycloud.secret_key = 'secret'
-      expect(Niftycloud.secret_key).to eq('secret')
+      Nifcloud.secret_key = 'secret'
+      expect(Nifcloud.secret_key).to eq('secret')
     end
   end
 
   describe ".user_agent" do
     it "should return default user_agent" do
-      expect(Niftycloud.user_agent).to eq(Niftycloud::Configuration::DEFAULT_USER_AGENT)
+      expect(Nifcloud.user_agent).to eq(Nifcloud::Configuration::DEFAULT_USER_AGENT)
     end
   end
 
   describe ".user_agent =" do
     it "should set user_agent" do
-      Niftycloud.user_agent = 'Custom User Agent'
-      expect(Niftycloud.user_agent).to eq('Custom User Agent')
+      Nifcloud.user_agent = 'Custom User Agent'
+      expect(Nifcloud.user_agent).to eq('Custom User Agent')
     end
   end
 
   describe ".configure" do
-    Niftycloud::Configuration::VALID_OPTIONS_KEYS.each do |key|
+    Nifcloud::Configuration::VALID_OPTIONS_KEYS.each do |key|
       it "should set #{key}" do
-        Niftycloud.configure do |config|
+        Nifcloud.configure do |config|
           config.send("#{key}=", key)
-          expect(Niftycloud.send(key)).to eq(key)
+          expect(Nifcloud.send(key)).to eq(key)
         end
       end
     end
   end
 
   describe ".http_proxy" do
-    it "delegates the method to Niftycloud::Request" do
-      Niftycloud.endpoint = 'https://api.example.com'
-      request = class_spy(Niftycloud::Request).as_stubbed_const
+    it "delegates the method to Nifcloud::Request" do
+      Nifcloud.endpoint = 'https://api.example.com'
+      request = class_spy(Nifcloud::Request).as_stubbed_const
 
-      Niftycloud.http_proxy('hogefugapiyo.com', 8080, 'hoge', 'fuga')
+      Nifcloud.http_proxy('hogefugapiyo.com', 8080, 'hoge', 'fuga')
       expect(request).to have_received(:set_proxy_config).
           with('hogefugapiyo.com', 8080, 'hoge', 'fuga')
     end
   end
 end
 
-describe Niftycloud do
+describe Nifcloud do
   it "has a version number" do
-    expect(Niftycloud::VERSION).not_to be nil
+    expect(Nifcloud::VERSION).not_to be nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,13 @@
 require 'rspec'
 require 'webmock/rspec'
 
-require File.expand_path('../../lib/niftycloud', __FILE__)
+require File.expand_path('../../lib/nifcloud', __FILE__)
 
 RSpec.configure do |config|
   config.before(:all) do
-    Niftycloud.endpoint = 'https://api.example.com'
-    Niftycloud.access_key = 'ABC'
-    Niftycloud.secret_key = '012'
+    Nifcloud.endpoint = 'https://api.example.com'
+    Nifcloud.access_key = 'ABC'
+    Nifcloud.secret_key = '012'
   end
 end
 
@@ -18,12 +18,12 @@ end
 # GET
 def stub_get(path, action, fixture, status_code=200)
   timestamp = Time.now.strftime("%Y%m%dT%H:%M:%SZ")
-  stub_request(:get, "#{Niftycloud.endpoint}#{path}").
+  stub_request(:get, "#{Nifcloud.endpoint}#{path}").
       with(query: {
           Action: action,
           Timestamp: timestamp,
-          AccessKeyId: Niftycloud.access_key,
-          Signature: Niftycloud::Signature.v0(Niftycloud.secret_key, "#{action}#{timestamp}"),
+          AccessKeyId: Nifcloud.access_key,
+          Signature: Nifcloud::Signature.v0(Nifcloud.secret_key, "#{action}#{timestamp}"),
           SignatureVersion: '0',
       }).
       to_return(body: load_fixture(fixture), status: status_code)
@@ -31,48 +31,48 @@ end
 
 def a_get(path, action)
   timestamp = Time.now.strftime("%Y%m%dT%H:%M:%SZ")
-  a_request(:get, "#{Niftycloud.endpoint}#{path}").
+  a_request(:get, "#{Nifcloud.endpoint}#{path}").
       with(query: {
           Action: action,
           Timestamp: timestamp,
-          AccessKeyId: Niftycloud.access_key,
-          Signature: Niftycloud::Signature.v0(Niftycloud.secret_key, "#{action}#{timestamp}"),
+          AccessKeyId: Nifcloud.access_key,
+          Signature: Nifcloud::Signature.v0(Nifcloud.secret_key, "#{action}#{timestamp}"),
           SignatureVersion: '0',
       })
 end
 
 # POST
 def stub_post(path, fixture, status_code=200)
-  stub_request(:post, "#{Niftycloud.endpoint}#{path}").
-      with(headers: {'PRIVATE-TOKEN' => Niftycloud.secret_key}).
+  stub_request(:post, "#{Nifcloud.endpoint}#{path}").
+      with(headers: {'PRIVATE-TOKEN' => Nifcloud.secret_key}).
       to_return(body: load_fixture(fixture), status: status_code)
 end
 
 def a_post(path)
-  a_request(:post, "#{Niftycloud.endpoint}#{path}").
-      with(headers: {'PRIVATE-TOKEN' => Niftycloud.secret_key})
+  a_request(:post, "#{Nifcloud.endpoint}#{path}").
+      with(headers: {'PRIVATE-TOKEN' => Nifcloud.secret_key})
 end
 
 # PUT
 def stub_put(path, fixture)
-  stub_request(:put, "#{Niftycloud.endpoint}#{path}").
-      with(headers: {'PRIVATE-TOKEN' => Niftycloud.secret_key}).
+  stub_request(:put, "#{Nifcloud.endpoint}#{path}").
+      with(headers: {'PRIVATE-TOKEN' => Nifcloud.secret_key}).
       to_return(body: load_fixture(fixture))
 end
 
 def a_put(path)
-  a_request(:put, "#{Niftycloud.endpoint}#{path}").
-      with(headers: {'PRIVATE-TOKEN' => Niftycloud.secret_key})
+  a_request(:put, "#{Nifcloud.endpoint}#{path}").
+      with(headers: {'PRIVATE-TOKEN' => Nifcloud.secret_key})
 end
 
 # DELETE
 def stub_delete(path, fixture)
-  stub_request(:delete, "#{Niftycloud.endpoint}#{path}").
-      with(headers: {'PRIVATE-TOKEN' => Niftycloud.secret_key}).
+  stub_request(:delete, "#{Nifcloud.endpoint}#{path}").
+      with(headers: {'PRIVATE-TOKEN' => Nifcloud.secret_key}).
       to_return(body: load_fixture(fixture))
 end
 
 def a_delete(path)
-  a_request(:delete, "#{Niftycloud.endpoint}#{path}").
-      with(headers: {'PRIVATE-TOKEN' => Niftycloud.secret_key})
+  a_request(:delete, "#{Nifcloud.endpoint}#{path}").
+      with(headers: {'PRIVATE-TOKEN' => Nifcloud.secret_key})
 end


### PR DESCRIPTION
- Renamed niftycloud to nifcloud.
- You should rename this repository name and description to nifcloud.